### PR TITLE
Solve

### DIFF
--- a/BLM/blm_batch.py
+++ b/BLM/blm_batch.py
@@ -53,7 +53,6 @@ def main(*args):
     X = pandas.io.parsers.read_csv(
         inputs['X'], sep=',', header=None).values
 
-    SVFlag = inputs['SVFlag']
     OutDir = inputs['outdir']
 
     # Load in one nifti to check NIFTI size
@@ -83,26 +82,22 @@ def main(*args):
     # with no studies present.
     Y, Mask = obtainY(Y_files, M_files)
 
-    # For spatially varying,
-    if SVFlag:
-        MX = blkMX(X, Y)
+    # Work out voxel specific designs
+    MX = blkMX(X, Y)
     
     # Get X transpose Y, X transpose X and Y transpose Y.
     XtY = blkXtY(X, Y, Mask)
     YtY = blkYtY(Y, Mask)
-    
-    if not SVFlag:
-        XtX = blkXtX(X)
-    else:
-        # In a spatially varying design XtX has dimensions n_voxels
-        # by n_parameters by n_parameters. We reshape to n_voxels by
-        # n_parameters^2 so that we can save as a csv.
-        XtX_m = blkXtX(MX)
-        XtX_m = XtX_m.reshape([XtX_m.shape[0], XtX_m.shape[1]*XtX_m.shape[2]])
 
-        # We then need to unmask XtX as we now are saving XtX.
-        XtX = np.zeros([Mask.shape[0],XtX_m.shape[1]])
-        XtX[np.flatnonzero(Mask),:] = XtX_m[:]
+    # In a spatially varying design XtX has dimensions n_voxels
+    # by n_parameters by n_parameters. We reshape to n_voxels by
+    # n_parameters^2 so that we can save as a csv.
+    XtX_m = blkXtX(MX)
+    XtX_m = XtX_m.reshape([XtX_m.shape[0], XtX_m.shape[1]*XtX_m.shape[2]])
+
+    # We then need to unmask XtX as we now are saving XtX.
+    XtX = np.zeros([Mask.shape[0],XtX_m.shape[1]])
+    XtX[np.flatnonzero(Mask),:] = XtX_m[:]
 
     # Pandas reads and writes files much more quickly with nrows <<
     # number of columns

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -403,6 +403,23 @@ def main(*args):
     # ----------------------------------------------------------------------
     print(resms.shape)
     iresms = 1/resms*np.identity(n_p,dtype=float) 
+    if SVFlag:
+        
+        # Calculate masked (x'X)^(-1) values
+        sumXtX_m = sumXtX[M_inds,:,:]
+        isumXtX_m = blm_inverse(sumXtX_m, SVFlag, ouflow=True).reshape([n_v_m, n_p*n_p])
+
+        # Make (X'X)^(-1) unmasked
+        isumXtX = np.zeros([n_v, n_p*n_p])
+        isumXtX[M_inds,:]=isumXtX_m
+        isumXtX = isumXtX.reshape([n_v, n_p, n_p])
+
+    # If we are not using a spatially varying design, inverse in
+    # the normal manner.
+    else:
+        # Calculate inverse of XtX
+        isumXtX = blm_inverse(sumXtX, SVFlag)
+        
     if not SVFlag:
 
         # Output variance for each pair of betas

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -307,6 +307,7 @@ def main(*args):
 
     beta = np.matmul(isumXtX, sumXtY)
     print(beta.shape)
+    print(sumXtY.shape)
     print(sumXtY[:, np.where(Mask==0)].shape)
     print(sumXtX.shape)
     beta2 = np.linalg.solve(sumXtX, sumXtY)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -37,7 +37,6 @@ def main(*args):
     # ----------------------------------------------------------------------
     # Read basic inputs
     # ----------------------------------------------------------------------
-    SVFlag = inputs['SVFlag']
     OutDir = inputs['outdir']
     
     # Get number of parameters
@@ -230,31 +229,24 @@ def main(*args):
         Mask[mmThresh==0]=0
 
 
-    # If spatially varying remove the designs that aren't of full rank.
-    if SVFlag:
+    # We remove anything with 1 degree of freedom (or less) by default.
+    # 1 degree of freedom seems to cause broadcasting errors on a very
+    # small percentage of voxels.
+    Mask[n_s_sv.reshape(n_v, 1)<=n_p+1]=0
 
-        # We remove anything with 1 degree of freedom (or less) by default.
-        # 1 degree of freedom seems to cause broadcasting errors on a very
-        # small percentage of voxels.
-        Mask[n_s_sv.reshape(n_v, 1)<=n_p+1]=0
+    # Reshape sumXtX to correct n_v by n_p by n_p
+    sumXtX = sumXtX.reshape([n_v, n_p, n_p])
 
-        # Reshape sumXtX to correct n_v by n_p by n_p
-        sumXtX = sumXtX.reshape([n_v, n_p, n_p])
+    # We also remove all voxels where the design has a column of just
+    # zeros.
+    for i in range(0,n_p):
+        Mask[np.where(sumXtX[:,i,i]==0)]=0
 
-        # We also remove all voxels where the design has a column of just
-        # zeros.
-        for i in range(0,n_p):
-            Mask[np.where(sumXtX[:,i,i]==0)]=0
-
-        # Remove voxels with designs without full rank.
-        M_inds = np.where(Mask==1)[0]
-        Mask[M_inds[np.where(
-            np.absolute(blm_det(sumXtX[M_inds,:,:],SVFlag)) < np.sqrt(sys.float_info.epsilon)
-            )]]=0
-
-    else:
-
-        Mask[n_s_sv.reshape(n_v, 1) == 0] = 0
+    # Remove voxels with designs without full rank.
+    M_inds = np.where(Mask==1)[0]
+    Mask[M_inds[np.where(
+        np.absolute(blm_det(sumXtX[M_inds,:,:])) < np.sqrt(sys.float_info.epsilon)
+        )]]=0
 
     # Output final mask map
     maskmap = nib.Nifti1Image(Mask.reshape(
@@ -276,32 +268,23 @@ def main(*args):
     # Calculate betahat = (X'X)^(-1)X'Y and output beta maps
     # ----------------------------------------------------------------------    
 
-    if SVFlag:
+    # Calculate masked X'X
+    sumXtX_m = sumXtX[M_inds,:,:]
+    isumXtX_m = blm_inverse(sumXtX_m, ouflow=True).reshape([n_v_m, n_p*n_p])
 
-        # Calculate masked X'X
-        sumXtX_m = sumXtX[M_inds,:,:]
-        isumXtX_m = blm_inverse(sumXtX_m, SVFlag, ouflow=True).reshape([n_v_m, n_p*n_p])
+    # Calculate masked X'Y
+    sumXtY = sumXtY.transpose()
+    sumXtY = sumXtY.reshape([n_v, n_p, 1])
+    sumXtY_m = sumXtY[M_inds,:]
 
-        # Calculate masked X'Y
-        sumXtY = sumXtY.transpose()
-        sumXtY = sumXtY.reshape([n_v, n_p, 1])
-        sumXtY_m = sumXtY[M_inds,:]
+    # Calculate masked Beta
+    beta_m = np.linalg.solve(sumXtX_m, sumXtY_m)
 
-        # Calculate masked Beta
-        beta_m = np.linalg.solve(sumXtX_m, sumXtY_m)
+    # Unmask Beta
+    beta = np.zeros([n_v, n_p])
+    beta[M_inds,:] = beta_m.reshape([n_v_m, n_p])
+    beta = beta.reshape([n_v, n_p]).transpose()
 
-        # Unmask Beta
-        beta = np.zeros([n_v, n_p])
-        beta[M_inds,:] = beta_m.reshape([n_v_m, n_p])
-        beta = beta.reshape([n_v, n_p]).transpose()
-
-    else:
-
-        # If we are doing non-spatially varying we still need to mask XtY
-        sumXtY[:, np.where(Mask==0)]=0
-
-        # Calculate beta
-        beta = np.linalg.solve(sumXtX, sumXtY)
 
     # Cycle through betas and output results.
     for i in range(0,beta.shape[0]):
@@ -363,34 +346,24 @@ def main(*args):
     # Calculate residual mean squares = e'e/(n_s - n_p)
     # ----------------------------------------------------------------------
 
-    # Get residual mean squares by dividing by degrees of
-    # freedom
-    if not SVFlag:
+    # Mask spatially varying n_s
+    n_s_sv_m = n_s_sv.reshape(n_v, 1)
+    n_s_sv_m = n_s_sv_m[M_inds,:]
 
-        # In non spatially varying the degrees of freedom
-        # are fixed across voxels
-        resms = ete/(n_s-n_p)
+    # Mask ete
+    ete_m = ete.reshape(n_v, 1)
+    ete_m = ete_m[M_inds,:]
 
-    else:
+    # In spatially varying the degrees of freedom
+    # varies across voxels
+    resms_m = ete_m/(n_s_sv_m-n_p)
 
-        # Mask spatially varying n_s
-        n_s_sv_m = n_s_sv.reshape(n_v, 1)
-        n_s_sv_m = n_s_sv_m[M_inds,:]
-
-        # Mask ete
-        ete_m = ete.reshape(n_v, 1)
-        ete_m = ete_m[M_inds,:]
-
-        # In spatially varying the degrees of freedom
-        # varies across voxels
-        resms_m = ete_m/(n_s_sv_m-n_p)
-
-        # Unmask resms
-        resms = np.zeros([n_v,1])
-        resms[M_inds,:] = resms_m
-        resms = resms.reshape(NIFTIsize[0], 
-                              NIFTIsize[1],
-                              NIFTIsize[2])
+    # Unmask resms
+    resms = np.zeros([n_v,1])
+    resms[M_inds,:] = resms_m
+    resms = resms.reshape(NIFTIsize[0], 
+                          NIFTIsize[1],
+                          NIFTIsize[2])
 
     # Output ResSS.
     msmap = nib.Nifti1Image(resms,
@@ -401,64 +374,36 @@ def main(*args):
     # ----------------------------------------------------------------------
     # Calculate beta covariance maps
     # ----------------------------------------------------------------------
-    if SVFlag:
         
-        # Calculate masked (x'X)^(-1) values
-        sumXtX_m = sumXtX[M_inds,:,:]
-        isumXtX_m = blm_inverse(sumXtX_m, SVFlag, ouflow=True).reshape([n_v_m, n_p*n_p])
+    # Calculate masked (x'X)^(-1) values
+    sumXtX_m = sumXtX[M_inds,:,:]
+    isumXtX_m = blm_inverse(sumXtX_m, ouflow=True).reshape([n_v_m, n_p*n_p])
 
-        # Make (X'X)^(-1) unmasked
-        isumXtX = np.zeros([n_v, n_p*n_p])
-        isumXtX[M_inds,:]=isumXtX_m
-        isumXtX = isumXtX.reshape([n_v, n_p, n_p])
+    # Make (X'X)^(-1) unmasked
+    isumXtX = np.zeros([n_v, n_p*n_p])
+    isumXtX[M_inds,:]=isumXtX_m
+    isumXtX = isumXtX.reshape([n_v, n_p, n_p])
 
-    # If we are not using a spatially varying design, inverse in
-    # the normal manner.
-    else:
-        # Calculate inverse of XtX
-        isumXtX = blm_inverse(sumXtX, SVFlag)
+    # Output variance for each pair of betas
+    for i in range(0,n_p):
+        for j in range(0,n_p):
 
-    if not SVFlag:
+                covbetaij = np.multiply(resms,
+                    isumXtX[:,i,j].reshape(
+                        NIFTIsize[0],
+                        NIFTIsize[1],
+                        NIFTIsize[2],
+                        ))
+                    
+                # Output covariance map
+                covbetaijmap = nib.Nifti1Image(covbetaij,
+                                               nifti.affine,
+                                               header=nifti.header)
+                nib.save(covbetaijmap,
+                    os.path.join(OutDir, 
+                        'blm_vox2_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
 
-        # Output variance for each pair of betas
-        for i in range(0,n_p):
-            for j in range(0,n_p):
-
-                    # Calculate covariance of beta i and beta j.
-                    covbetaij = resms*isumXtX[i,j]
-
-                    # Output covariance map
-                    covbetaijmap = nib.Nifti1Image(covbetaij,
-                                                   nifti.affine,
-                                                   header=nifti.header)
-                    nib.save(covbetaijmap,
-                        os.path.join(OutDir, 
-                            'blm_vox2_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
-
-        del covbetaijmap
-
-    else:
-
-        # Output variance for each pair of betas
-        for i in range(0,n_p):
-            for j in range(0,n_p):
-
-                    covbetaij = np.multiply(resms,
-                        isumXtX[:,i,j].reshape(
-                            NIFTIsize[0],
-                            NIFTIsize[1],
-                            NIFTIsize[2],
-                            ))
-                        
-                    # Output covariance map
-                    covbetaijmap = nib.Nifti1Image(covbetaij,
-                                                   nifti.affine,
-                                                   header=nifti.header)
-                    nib.save(covbetaijmap,
-                        os.path.join(OutDir, 
-                            'blm_vox2_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
-
-        del covbetaijmap
+    del covbetaijmap
 
     # ----------------------------------------------------------------------
     # Calculate COPEs, statistic maps and covariance maps.
@@ -494,60 +439,34 @@ def main(*args):
                 os.path.join(OutDir, 
                     'blm_vox_beta_c' + str(i+1) + '.nii'))
 
-            if not SVFlag:
+            XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
+            cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
 
-                print(cvec.shape)
-                XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
-                cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
+            # Calculate c'(X'X)^(-1)c
+            cvectiXtXcvec = np.matmul(
+                np.matmul(cvec, isumXtX),
+                np.transpose(cvec))
 
-                # Calculate c'(X'X)^(-1)c
-                cvectiXtXcvec = np.matmul(
-                    np.matmul(cvec, isumXtX),
-                    np.transpose(cvec))
+            print(cvectiXtXcvec.shape)
+            print(cvectiXtXcvec2.shape)
+            print(cvectiXtXcvec==cvectiXtXcvec2)
 
-                # Calculate cov(c\hat{\beta})
-                covcbeta = cvectiXtXcvec*resms
+            # Calculate cov(c\hat{\beta})
+            covcbeta = cvectiXtXcvec*resms.reshape(n_v)
 
-                # Output covariance map
-                covcbetamap = nib.Nifti1Image(covcbeta,
-                                              nifti.affine,
-                                              header=nifti.header)
-                nib.save(covcbetamap,
-                    os.path.join(OutDir, 
-                        'blm_vox_cov_c' + str(i+1) + '.nii'))
+            covcbeta = covcbeta.reshape(
+                NIFTIsize[0],
+                NIFTIsize[1],
+                NIFTIsize[2]
+                )
 
-            else:
-
-                print(cvec.shape)
-
-                XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
-                cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
-
-                # Calculate c'(X'X)^(-1)c
-                cvectiXtXcvec = np.matmul(
-                    np.matmul(cvec, isumXtX),
-                    np.transpose(cvec))
-
-                print(cvectiXtXcvec.shape)
-                print(cvectiXtXcvec2.shape)
-                print(cvectiXtXcvec==cvectiXtXcvec2)
-
-                # Calculate cov(c\hat{\beta})
-                covcbeta = cvectiXtXcvec*resms.reshape(n_v)
-
-                covcbeta = covcbeta.reshape(
-                    NIFTIsize[0],
-                    NIFTIsize[1],
-                    NIFTIsize[2]
-                    )
-
-                # Output covariance map
-                covcbetamap = nib.Nifti1Image(covcbeta,
-                                              nifti.affine,
-                                              header=nifti.header)
-                nib.save(covcbetamap,
-                    os.path.join(OutDir, 
-                        'blm_vox_cov_c' + str(i+1) + '.nii'))
+            # Output covariance map
+            covcbetamap = nib.Nifti1Image(covcbeta,
+                                          nifti.affine,
+                                          header=nifti.header)
+            nib.save(covcbetamap,
+                os.path.join(OutDir, 
+                    'blm_vox_cov_c' + str(i+1) + '.nii'))
 
 
             # To avoid division by zero errors we set the 
@@ -584,23 +503,15 @@ def main(*args):
                 cbeta.shape[1],
                 1)
             cbeta = cbeta.transpose(1, 0, 2)
-        
-            # Not spatially varying
-            if not SVFlag:
 
-                # Calculate the inverse
-                icvectiXtXcvec = blm_inverse(cvectiXtXcvec, SVFlag, ouflow=True)
+            # Calculate masked (c'(X'X)^(-1)c)^(-1) values
+            cvectiXtXcvec_m = cvectiXtXcvec[M_inds,:,:]
+            icvectiXtXcvec_m = blm_inverse(cvectiXtXcvec_m, ouflow=True).reshape([n_v_m, q*q])
 
-            else:
-
-                # Calculate masked (c'(X'X)^(-1)c)^(-1) values
-                cvectiXtXcvec_m = cvectiXtXcvec[M_inds,:,:]
-                icvectiXtXcvec_m = blm_inverse(cvectiXtXcvec_m, SVFlag, ouflow=True).reshape([n_v_m, q*q])
-
-                # Make (c'(X'X)^(-1)c)^(-1) unmasked
-                icvectiXtXcvec = np.zeros([n_v, q*q])
-                icvectiXtXcvec[M_inds,:]=icvectiXtXcvec_m
-                icvectiXtXcvec = icvectiXtXcvec.reshape([n_v, q, q])
+            # Make (c'(X'X)^(-1)c)^(-1) unmasked
+            icvectiXtXcvec = np.zeros([n_v, q*q])
+            icvectiXtXcvec[M_inds,:]=icvectiXtXcvec_m
+            icvectiXtXcvec = icvectiXtXcvec.reshape([n_v, q, q])
 
 
             # Calculate the numerator of the F statistic
@@ -649,37 +560,28 @@ def main(*args):
 # special handling is used to account for over/under
 # flow. In this case, it assumes that A has non-zero
 # diagonals.
-def blm_inverse(A, SVFlag, ouflow=False):
+def blm_inverse(A, ouflow=False):
 
 
     # If ouflow is true, we need to precondition A.
     if ouflow:
 
-        if not SVFlag:
+        # Work out number of matrices and dimension of
+        # matrices. I.e. if we have seven 3 by 3 matrices
+        # to invert n_m = 7, d_m = 3.
+        n_m = A.shape[0]
+        d_m = A.shape[1]
 
-            # Calculate D, diagonal matrix with diagonal
-            # elements D_ii equal to 1/sqrt(A_ii)
-            D = np.zeros(A.shape)
-            np.fill_diagonal(D, 1/np.sqrt(A.diagonal()))
+        # Make D to be filled with diagonal elements
+        D = np.broadcast_to(np.eye(d_m), (n_m,d_m,d_m)).copy()
 
-        else:
+        # Obtain 1/sqrt(diagA)
+        diagA = 1/np.sqrt(A.diagonal(0,1,2))
+        diagA = diagA.reshape(n_m, d_m)
 
-            # Work out number of matrices and dimension of
-            # matrices. I.e. if we have seven 3 by 3 matrices
-            # to invert n_m = 7, d_m = 3.
-            n_m = A.shape[0]
-            d_m = A.shape[1]
-
-            # Make D to be filled with diagonal elements
-            D = np.broadcast_to(np.eye(d_m), (n_m,d_m,d_m)).copy()
-
-            # Obtain 1/sqrt(diagA)
-            diagA = 1/np.sqrt(A.diagonal(0,1,2))
-            diagA = diagA.reshape(n_m, d_m)
-
-            # Make this back into diagonal matrices
-            diaginds = np.diag_indices(d_m)
-            D[:, diaginds[0], diaginds[1]] = diagA 
+        # Make this back into diagonal matrices
+        diaginds = np.diag_indices(d_m)
+        D[:, diaginds[0], diaginds[1]] = diagA 
 
         # Precondition A.
         A = np.matmul(np.matmul(D, A), D)
@@ -700,35 +602,26 @@ def blm_inverse(A, SVFlag, ouflow=False):
 # This function calculates the determinant of matrix A/
 # stack of matrices A, with special handling accounting
 # for over/under flow. 
-def blm_det(A, SVFlag):
+def blm_det(A):
 
 
     # Precondition A.
-    if not SVFlag:
+    # Work out number of matrices and dimension of
+    # matrices. I.e. if we have seven 3 by 3 matrices
+    # to invert n_m = 7, d_m = 3.
+    n_m = A.shape[0]
+    d_m = A.shape[1]
 
-        # Calculate D, diagonal matrix with diagonal
-        # elements D_ii equal to 1/sqrt(A_ii)
-        D = np.zeros(A.shape)
-        np.fill_diagonal(D, 1/np.sqrt(A.diagonal()))
+    # Make D to be filled with diagonal elements
+    D = np.broadcast_to(np.eye(d_m), (n_m,d_m,d_m)).copy()
 
-    else:
+    # Obtain 1/sqrt(diagA)
+    diagA = 1/np.sqrt(A.diagonal(0,1,2))
+    diagA = diagA.reshape(n_m, d_m)
 
-        # Work out number of matrices and dimension of
-        # matrices. I.e. if we have seven 3 by 3 matrices
-        # to invert n_m = 7, d_m = 3.
-        n_m = A.shape[0]
-        d_m = A.shape[1]
-
-        # Make D to be filled with diagonal elements
-        D = np.broadcast_to(np.eye(d_m), (n_m,d_m,d_m)).copy()
-
-        # Obtain 1/sqrt(diagA)
-        diagA = 1/np.sqrt(A.diagonal(0,1,2))
-        diagA = diagA.reshape(n_m, d_m)
-
-        # Make this back into diagonal matrices
-        diaginds = np.diag_indices(d_m)
-        D[:, diaginds[0], diaginds[1]] = diagA 
+    # Make this back into diagonal matrices
+    diaginds = np.diag_indices(d_m)
+    D[:, diaginds[0], diaginds[1]] = diagA 
 
     # Calculate DAD.
     DAD = np.matmul(np.matmul(D, A), D)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -402,6 +402,7 @@ def main(*args):
     # Calculate beta covariance maps
     # ----------------------------------------------------------------------
     print(resms.shape)
+    iresms = 1/resms*np.identity(n_p,dtype=float) 
     if not SVFlag:
 
         # Output variance for each pair of betas
@@ -410,6 +411,7 @@ def main(*args):
 
                     # Calculate covariance of beta i and beta j.
                     covbetaij = resms*isumXtX[i,j]
+                    covbetaij2 = np.linalg.solve(sumXtX, iresms)[:,i,j]
 
                     # Output covariance map
                     covbetaijmap = nib.Nifti1Image(covbetaij,
@@ -417,7 +419,7 @@ def main(*args):
                                                    header=nifti.header)
                     nib.save(covbetaijmap,
                         os.path.join(OutDir, 
-                            'blm_vox_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
+                            'blm_vox2_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
 
         del covbetaijmap
 
@@ -433,6 +435,7 @@ def main(*args):
                             NIFTIsize[1],
                             NIFTIsize[2],
                             ))
+                    covbetaij2 = np.linalg.solve(sumXtX, iresms)[:,i,j]
                         
                     # Output covariance map
                     covbetaijmap = nib.Nifti1Image(covbetaij,
@@ -440,7 +443,7 @@ def main(*args):
                                                    header=nifti.header)
                     nib.save(covbetaijmap,
                         os.path.join(OutDir, 
-                            'blm_vox_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
+                            'blm_vox2_cov_b' + str(i+1) + ',' + str(j+1) + '.nii'))
 
         del covbetaijmap
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -439,8 +439,8 @@ def main(*args):
                 os.path.join(OutDir, 
                     'blm_vox_beta_c' + str(i+1) + '.nii'))
 
-            XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
-            cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
+            #XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
+            #cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
 
             # Calculate c'(X'X)^(-1)c
             cvectiXtXcvec = np.matmul(

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -401,8 +401,6 @@ def main(*args):
     # ----------------------------------------------------------------------
     # Calculate beta covariance maps
     # ----------------------------------------------------------------------
-    print(resms.shape)
-    iresms = 1/resms*np.identity(n_p,dtype=float) 
     if SVFlag:
         
         # Calculate masked (x'X)^(-1) values
@@ -419,7 +417,7 @@ def main(*args):
     else:
         # Calculate inverse of XtX
         isumXtX = blm_inverse(sumXtX, SVFlag)
-        
+
     if not SVFlag:
 
         # Output variance for each pair of betas
@@ -498,6 +496,9 @@ def main(*args):
 
             if not SVFlag:
 
+                XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
+                cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
+
                 # Calculate c'(X'X)^(-1)c
                 cvectiXtXcvec = np.matmul(
                     np.matmul(cvec, isumXtX),
@@ -516,10 +517,17 @@ def main(*args):
 
             else:
 
+                XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
+                cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
+
                 # Calculate c'(X'X)^(-1)c
                 cvectiXtXcvec = np.matmul(
                     np.matmul(cvec, isumXtX),
                     np.transpose(cvec))
+
+                print(cvectiXtXcvec.shape)
+                print(cvectiXtXcvec2.shape)
+                print(cvectiXtXcvec==cvectiXtXcvec2)
 
                 # Calculate cov(c\hat{\beta})
                 covcbeta = cvectiXtXcvec*resms.reshape(n_v)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -494,6 +494,7 @@ def main(*args):
 
             if not SVFlag:
 
+                print(cvec.shape)
                 XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
                 cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -319,6 +319,8 @@ def main(*args):
         # Calculate beta
         beta2 = np.linalg.solve(sumXtX, sumXtY)
 
+    beta = np.matmul(isumXtX, sumXtY)
+
     print(beta==beta2)
 
     if SVFlag:

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -426,7 +426,6 @@ def main(*args):
 
                     # Calculate covariance of beta i and beta j.
                     covbetaij = resms*isumXtX[i,j]
-                    covbetaij2 = np.linalg.solve(sumXtX, iresms)[:,i,j]
 
                     # Output covariance map
                     covbetaijmap = nib.Nifti1Image(covbetaij,
@@ -450,7 +449,6 @@ def main(*args):
                             NIFTIsize[1],
                             NIFTIsize[2],
                             ))
-                    covbetaij2 = np.linalg.solve(sumXtX, iresms)[:,i,j]
                         
                     # Output covariance map
                     covbetaijmap = nib.Nifti1Image(covbetaij,

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -270,7 +270,6 @@ def main(*args):
 
     # Calculate masked X'X
     sumXtX_m = sumXtX[M_inds,:,:]
-    isumXtX_m = blm_inverse(sumXtX_m, ouflow=True).reshape([n_v_m, n_p*n_p])
 
     # Calculate masked X'Y
     sumXtY = sumXtY.transpose()

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -447,8 +447,8 @@ def main(*args):
                 np.transpose(cvec))
 
             print(cvectiXtXcvec.shape)
-            print(cvectiXtXcvec2.shape)
-            print(cvectiXtXcvec==cvectiXtXcvec2)
+            #print(cvectiXtXcvec2.shape)
+            #print(cvectiXtXcvec==cvectiXtXcvec2)
 
             # Calculate cov(c\hat{\beta})
             covcbeta = cvectiXtXcvec*resms.reshape(n_v)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -308,7 +308,10 @@ def main(*args):
     if SVFlag:
 
         # Calculate Beta
+        print(sumXtX_m.shape)
+        print(sumXtY.shape)
         beta2_m = np.linalg.solve(sumXtX_m, sumXtY)
+        print(beta2_m.shape)
 
         # Unmask Beta
         beta2 = np.zeros([n_v, n_p])

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -447,6 +447,7 @@ def main(*args):
                 np.transpose(cvec))
 
             print(cvectiXtXcvec.shape)
+            print(resms.shape)
             #print(cvectiXtXcvec2.shape)
             #print(cvectiXtXcvec==cvectiXtXcvec2)
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -307,7 +307,7 @@ def main(*args):
 
     beta = np.matmul(isumXtX, sumXtY)
     print(beta.shape)
-    print(sumXtY.shape)
+    print(sumXtY[:, np.where(Mask==0)].shape)
     print(sumXtX.shape)
     beta2 = np.linalg.solve(sumXtX, sumXtY)
     print(beta2.shape)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -418,6 +418,7 @@ def main(*args):
 
         # Calculate C\hat{\beta}}
         cbeta = np.matmul(cvec, beta)
+        np.matmul(cvec, isumXtX)#TESTING ERROR
         if cvec.ndim == 1:
             cvec = cvec.reshape([cvec.shape[0],1])
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -317,6 +317,7 @@ def main(*args):
         # Unmask Beta
         beta2 = np.zeros([n_v, n_p])
         beta2[M_inds,:] = beta2_m.reshape([n_v_m, n_p])
+        beta2 = beta2.reshape([n_v, n_p]).transpose()
 
     else:
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -297,6 +297,7 @@ def main(*args):
     if SVFlag:
         sumXtY = sumXtY.transpose()
         sumXtY = sumXtY.reshape([n_v, n_p, 1])
+        sumXtY_m = sumXtY[M_inds,:]
     else:
         # If we are doing non-spatially varying we still need to mask XtY
         sumXtY[:, np.where(Mask==0)]=0

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -311,7 +311,7 @@ def main(*args):
         # Calculate Beta
         print(sumXtX_m.shape)
         print(sumXtY.shape)
-        beta2_m = np.linalg.solve(sumXtX_m, sumXtY)
+        beta2_m = np.linalg.solve(sumXtX_m, sumXtY_m)
         print(beta2_m.shape)
 
         # Unmask Beta

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -418,9 +418,8 @@ def main(*args):
 
         # Calculate C\hat{\beta}}
         cbeta = np.matmul(cvec, beta)
-        np.matmul(cvec, isumXtX)#TESTING ERROR
         if cvec.ndim == 1:
-            cvec = cvec.reshape([cvec.shape[0],1])
+            cvec = cvec.reshape([1,cvec.shape[0]])
 
         if inputs['contrasts'][i]['c' + str(i+1)]['statType'] == 'T':
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -316,7 +316,7 @@ def main(*args):
 
         # Unmask Beta
         beta2 = np.zeros([n_v, n_p])
-        beta2[M_inds,:] = beta2_m
+        beta2[M_inds,:] = beta2_m.reshape([n_v_m, n_p])
 
     else:
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -305,14 +305,20 @@ def main(*args):
     # Calculate betahat = (X'X)^(-1)X'Y and output beta maps
     # ----------------------------------------------------------------------    
 
-    beta = np.matmul(isumXtX, sumXtY)
-    print(beta.shape)
-    print(sumXtY.shape)
-    print(sumXtY[:, np.where(Mask==0)].shape)
-    print(np.where(Mask==0))
-    print(sumXtX.shape)
-    beta2 = np.linalg.solve(sumXtX, sumXtY)
-    print(beta2.shape)
+    if SVFlag:
+
+        # Calculate Beta
+        beta2_m = np.linalg.solve(sumXtX_m, sumXtY)
+
+        # Unmask Beta
+        beta2 = np.zeros([n_v, n_p])
+        beta2[M_inds,:] = beta2_m
+
+    else:
+
+        # Calculate beta
+        beta2 = np.linalg.solve(sumXtX, sumXtY)
+
     print(beta==beta2)
 
     if SVFlag:

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -306,6 +306,12 @@ def main(*args):
     # ----------------------------------------------------------------------    
 
     beta = np.matmul(isumXtX, sumXtY)
+    print(beta.shape)
+    print(sumXtY.shape)
+    print(sumXtX.shape)
+    beta2 = np.linalg.solve(sumXtX, sumXtY)
+    print(beta2.shape)
+    print(beta==beta2)
 
     if SVFlag:
         beta = beta.reshape([n_v, n_p]).transpose()

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -322,6 +322,8 @@ def main(*args):
     beta = np.matmul(isumXtX, sumXtY)
 
     print(beta==beta2)
+    print(beta.shape)
+    print(beta2.shape)
 
     if SVFlag:
         beta = beta.reshape([n_v, n_p]).transpose()
@@ -338,6 +340,16 @@ def main(*args):
                                    nifti.affine,
                                    header=nifti.header)
         nib.save(betaimap, os.path.join(OutDir,'blm_vox_beta_b' + str(i+1) + '.nii'))
+
+        beta2i = beta2[i,:].reshape(int(NIFTIsize[0]),
+                                  int(NIFTIsize[1]),
+                                  int(NIFTIsize[2]))
+
+        # Save beta map.
+        beta2imap = nib.Nifti1Image(beta2i,
+                                   nifti.affine,
+                                   header=nifti.header)
+        nib.save(beta2imap, os.path.join(OutDir,'blm_vox2_beta_b' + str(i+1) + '.nii'))
 
     del betai, betaimap
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -309,6 +309,7 @@ def main(*args):
     print(beta.shape)
     print(sumXtY.shape)
     print(sumXtY[:, np.where(Mask==0)].shape)
+    print(np.where(Mask==0))
     print(sumXtX.shape)
     beta2 = np.linalg.solve(sumXtX, sumXtY)
     print(beta2.shape)

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -516,6 +516,8 @@ def main(*args):
 
             else:
 
+                print(cvec.shape)
+
                 XtXcvec = np.linalg.solve(sumXtX,np.transpose(cvec))
                 cvectiXtXcvec2 = np.matmul(cvec,XtXcvec)
 

--- a/BLM/blm_concat.py
+++ b/BLM/blm_concat.py
@@ -474,6 +474,8 @@ def main(*args):
 
         # Calculate C\hat{\beta}}
         cbeta = np.matmul(cvec, beta)
+        if cvec.ndim == 1:
+            cvec = cvec.reshape([cvec.shape[0],1])
 
         if inputs['contrasts'][i]['c' + str(i+1)]['statType'] == 'T':
 

--- a/blm_defaults.yml
+++ b/blm_defaults.yml
@@ -10,9 +10,6 @@ M_files: /users/nichols/inf852/tmp2/M_200.txt
 # Design matrix and number of parameters.
 X: /users/nichols/inf852/tmp2/X_200.csv
 
-# Set this to true if you want a spatially varying analysis and false otherwise.
-SVFlag: True
-
 # There should be an output directory here:
 outdir: /users/nichols/inf852/BLM-py/BLM/test/200ukbbs_3p/
 

--- a/cluster_blm_main.sh
+++ b/cluster_blm_main.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 rm log/*
 
 # include parse_yaml function


### PR DESCRIPTION
This PR is a WIP. It uses Solve to replace matrix inversion when calculating \hat{\beta}.

Note: Cov(\hat{\beta}) is still calculated using `blm_inverse` as this was just a simple case of an inverse matrix multiplied by a constant and couldn't be improved with solve