### PR TITLE
Relative path fix

### DIFF
--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -71,12 +71,12 @@ def main(*args):
             if ("Masking" in inputs["Missingness"]) or ("masking" in inputs["Missingness"]):
 
                 # Read in threshold mask
-                if not os.path.isabs(inputs["Missingness"]["Masking"]):
-                    if "Masking" in inputs["Missingness"]:
+                if "Masking" in inputs["Missingness"]:
+                    if not os.path.isabs(inputs["Missingness"]["Masking"]):
                         inputs["Missingness"]["Masking"] = os.path.join(pwd, inputs["Missingness"]["Masking"])
 
-                if not os.path.isabs(inputs["Missingness"]["masking"]):
-                    if "Masking" in inputs["Missingness"]:
+                if "Masking" in inputs["Missingness"]:
+                    if not os.path.isabs(inputs["Missingness"]["masking"]):
                         inputs["Missingness"]["masking"] = os.path.join(pwd, inputs["Missingness"]["masking"])
 
         # Update inputs

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -25,7 +25,7 @@ def main(*args):
             inputs = yaml.load(stream)
     else:
         if type(args[0]) is str:
-            ipath = os.fullpath(pwd, args[0])
+            ipath = s.path.abspath(os.path.join(pwd, args[0]))
             # In this case inputs file is first argument
             with ipath as stream:
                 inputs = yaml.load(stream)

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -10,28 +10,79 @@ import sys
 import os
 import shutil
 import yaml
-import time
 from BLM.blm_eval import blm_eval
 
 def main(*args):
 
-    t1 = time.time()
-
     # Change to blm directory
+    pwd = os.getcwd()
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
     if len(args)==0 or (not args[0]):
         # Load in inputs
-        with open(os.path.join('..','blm_config.yml'), 'r') as stream:
+        inpath = os.path.abspath(os.path.join('..','blm_config.yml'))
+        with open(ipath 'r') as stream:
             inputs = yaml.load(stream)
     else:
         if type(args[0]) is str:
+            ipath = os.fullpath(pwd, args[0])
             # In this case inputs file is first argument
-            with open(os.path.join(args[0]), 'r') as stream:
+            with ipath as stream:
                 inputs = yaml.load(stream)
         else:  
             # In this case inputs structure is first argument.
             inputs = args[0]
+            ipath = ''
+
+    # Save absolute filepaths in place of relative filepaths
+    if ipath: 
+
+        # Y files
+        if not os.path.isabs(inputs['Y_files']):
+
+            # Change Y in inputs
+            inputs['Y_files'] = os.path.join(pwd, inputs['Y_files'])
+
+        # If mask files are specified
+        if 'M_files' in inputs:
+
+            # M_files
+            if not os.path.isabs(inputs['M_files']):
+
+                # Change M in inputs
+                inputs['M_files'] = os.path.join(pwd, inputs['M_files'])
+
+        # If X is specified
+        if not os.path.isabs(inputs['X']):
+
+            # Change X in inputs
+            inputs['X'] = os.path.join(pwd, inputs['X'])
+
+        if not os.path.isabs(inputs['outdir']):
+
+            # Change output directory in inputs
+            inputs['outdir'] = os.path.join(pwd, inputs['outdir'])
+
+        # Change missingness mask in inputs
+        if 'Missingness' in inputs:
+
+            if ("Masking" in inputs["Missingness"]) or ("masking" in inputs["Missingness"]):
+
+                # Read in threshold mask
+                if not os.path.isabs(inputs["Missingness"]["Masking"]):
+                    if "Masking" in inputs["Missingness"]:
+                        inputs["Missingness"]["Masking"] = os.path.join(pwd, inputs["Missingness"]["Masking"])
+
+                if not os.path.isabs(inputs["Missingness"]["masking"]):
+                    if "Masking" in inputs["Missingness"]:
+                        inputs["Missingness"]["masking"] = os.path.join(pwd, inputs["Missingness"]["masking"])
+
+        # Update inputs
+        with open(ipath, 'w') as outfile:
+            yaml.dump(inputs, outfile, default_flow_style=False)
+
+
+    # Change paths to absoluate if they aren't already
     
     if 'MAXMEM' in inputs:
         MAXMEM = eval(inputs['MAXMEM'])

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -27,7 +27,7 @@ def main(*args):
         if type(args[0]) is str:
             ipath = os.path.abspath(os.path.join(pwd, args[0]))
             # In this case inputs file is first argument
-            with ipath as stream:
+            with open(ipath, 'r') as stream:
                 inputs = yaml.load(stream)
         else:  
             # In this case inputs structure is first argument.

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -25,7 +25,7 @@ def main(*args):
             inputs = yaml.load(stream)
     else:
         if type(args[0]) is str:
-            ipath = s.path.abspath(os.path.join(pwd, args[0]))
+            ipath = os.path.abspath(os.path.join(pwd, args[0]))
             # In this case inputs file is first argument
             with ipath as stream:
                 inputs = yaml.load(stream)

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -12,6 +12,12 @@ import shutil
 import yaml
 from BLM.blm_eval import blm_eval
 
+# Main takes in two arguments at most:
+# - input: Either the path to an input file or an input structure
+#          with all paths already set to absolute.
+# - retnb: A boolean which tells us whether to return the number
+#          of batches needed (retnb=True) or save the variable
+#          in a text file (retnb=False).
 def main(*args):
 
     # Change to blm directory

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -34,6 +34,8 @@ def main(*args):
             inputs = args[0]
             ipath = ''
 
+    print(ipath)
+
     # Save absolute filepaths in place of relative filepaths
     if ipath: 
 
@@ -81,6 +83,8 @@ def main(*args):
         with open(ipath, 'w') as outfile:
             yaml.dump(inputs, outfile, default_flow_style=False)
 
+
+    print(os.path.isabs(inputs['Y_files']))
 
     # Change paths to absoluate if they aren't already
     

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -99,6 +99,8 @@ def main(*args):
     c1 = blm_eval(inputs['contrasts'][0]['c' + str(1)]['vector'])
     c1 = np.array(c1)
     n_p = c1.shape[0]
+    print('np')
+    print(n_p)
     del c1
 
     # Make output directory and tmp
@@ -114,6 +116,9 @@ def main(*args):
         for line in a.readlines():
 
             Y_files.append(line.replace('\n', ''))
+
+        print('Y_files')
+        print(Y_files)
 
     # Load in one nifti to check NIFTI size
     try:
@@ -134,6 +139,8 @@ def main(*args):
     # and then also divide though everything by the number of parameters
     # in the analysis.
     blksize = np.floor(MAXMEM/8/NIFTIsize/n_p);
+    print('blocksize')
+    print(blksize)
     if blksize == 0:
         raise ValueError('Blocksize too small.')
 

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -20,8 +20,8 @@ def main(*args):
 
     if len(args)==0 or (not args[0]):
         # Load in inputs
-        inpath = os.path.abspath(os.path.join('..','blm_config.yml'))
-        with open(ipath 'r') as stream:
+        ipath = os.path.abspath(os.path.join('..','blm_config.yml'))
+        with open(ipath, 'r') as stream:
             inputs = yaml.load(stream)
     else:
         if type(args[0]) is str:

--- a/BLM/blm_setup.py
+++ b/BLM/blm_setup.py
@@ -75,7 +75,7 @@ def main(*args):
                     if not os.path.isabs(inputs["Missingness"]["Masking"]):
                         inputs["Missingness"]["Masking"] = os.path.join(pwd, inputs["Missingness"]["Masking"])
 
-                if "Masking" in inputs["Missingness"]:
+                if "masking" in inputs["Missingness"]:
                     if not os.path.isabs(inputs["Missingness"]["masking"]):
                         inputs["Missingness"]["masking"] = os.path.join(pwd, inputs["Missingness"]["masking"])
 

--- a/blm_cluster.sh
+++ b/blm_cluster.sh
@@ -79,6 +79,10 @@ if [ "$printOpt" == "1" ] ; then
   echo "Submitting batch jobs..."
 fi
 
+# Reread yaml file in case filepaths have been updated to be absolute
+eval $(parse_yaml $inputs "config_")
+inputs=$config_outdir/inputs.yml
+
 i=1
 while [ "$i" -le "$nb" ]; do
 

--- a/blm_serial.py
+++ b/blm_serial.py
@@ -17,11 +17,12 @@ def main(*args):
     else:
         # Load in inputs
         ipath = args[0]
-        with open(args[0], 'r') as stream:
+        with open(ipath, 'r') as stream:
             inputs = yaml.load(stream)
 
     # Run the setup job to obtain the number of batches needed.
-    nB = blm_setup.main(ipath)
+    # retnb tells setup to return nB rather than save it
+    nB = blm_setup.main(ipath, retnb=True)
 
     # Run batch jobs and concatenate results
     print('Running batch 1/' + str(nB))

--- a/blm_serial.py
+++ b/blm_serial.py
@@ -11,18 +11,21 @@ def main(*args):
 
     if len(args)==0:
         ipath = os.path.join(os.getcwd(),'blm_config.yml')
-        # Load in inputs
-        with open(ipath, 'r') as stream:
-            inputs = yaml.load(stream)
     else:
-        # Load in inputs
         ipath = args[0]
-        with open(ipath, 'r') as stream:
-            inputs = yaml.load(stream)
+    
+    # Load in inputs
+    with open(ipath, 'r') as stream:
+        inputs = yaml.load(stream)
 
     # Run the setup job to obtain the number of batches needed.
     # The second argument tells setup to return nB rather than save it
     nB = blm_setup.main(ipath, True)
+
+    # Reload inputs (setup may have changed paths in inputs if they
+    # were relative).
+    with open(ipath, 'r') as stream:
+        inputs = yaml.load(stream)
 
     # Run batch jobs and concatenate results
     print('Running batch 1/' + str(nB))

--- a/blm_serial.py
+++ b/blm_serial.py
@@ -21,8 +21,8 @@ def main(*args):
             inputs = yaml.load(stream)
 
     # Run the setup job to obtain the number of batches needed.
-    # retnb tells setup to return nB rather than save it
-    nB = blm_setup.main(ipath, retnb=True)
+    # The second argument tells setup to return nB rather than save it
+    nB = blm_setup.main(ipath, True)
 
     # Run batch jobs and concatenate results
     print('Running batch 1/' + str(nB))

--- a/blm_serial.py
+++ b/blm_serial.py
@@ -10,16 +10,18 @@ def main(*args):
     print('Setting up analysis...')
 
     if len(args)==0:
+        ipath = os.path.join(os.getcwd(),'blm_config.yml')
         # Load in inputs
-        with open(os.path.join(os.getcwd(),'blm_config.yml'), 'r') as stream:
+        with open(ipath, 'r') as stream:
             inputs = yaml.load(stream)
     else:
         # Load in inputs
+        ipath = args[0]
         with open(args[0], 'r') as stream:
             inputs = yaml.load(stream)
 
     # Run the setup job to obtain the number of batches needed.
-    nB = blm_setup.main(inputs)
+    nB = blm_setup.main(ipath)
 
     # Run batch jobs and concatenate results
     print('Running batch 1/' + str(nB))


### PR DESCRIPTION
This is a fix to a user reported bug that relative paths do not work in the `blm_config` file. To address this the setup job reads the file and replaces any relative paths with absolute paths. As all batches need to access the `blm_config.yml` file this seemed like the safest option to ensure all paths are correctly specified.